### PR TITLE
run a shell if command is left empty and interactive mode is set

### DIFF
--- a/qed
+++ b/qed
@@ -278,6 +278,10 @@ case ${action} in
 		;;
 
 	run)
+		# run a shell if command is left empty and interactive mode is set
+		if [ -z "$*" ] && [ -n "${interactive}" ]; then
+			set -- ${SHELL:-/bin/sh}
+		fi
 		docker_prepare
 		docker_exec "$@"
 		;;


### PR DESCRIPTION
As a result,
```
$ qed -i
qed: running command '/bin/bash' on ubuntu:14.04
gportay@qed-ae00f783-openwrt-chaoscalmer-ubuntu-14-04:~/openwrt-chaoscalmer$
```
opens an interactive shell inside docker, while
```
$ qed

qed: no command to execute supplied

```
terminates in error.